### PR TITLE
Add go.mod and bump Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
 
 go:
-  - 1.7
-  - 1.8
-  - 1.9
+  - 1.13.x
+  - 1.14.x
+
+env:
+  - CGO_ENABLED=0
 
 script: travis_wait 20 go test ./... -v -parallel 10 -timeout 60m

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ go:
 env:
   - CGO_ENABLED=0
 
-script: travis_wait 20 go test ./... -v -parallel 5 -timeout 60m
+script: travis_wait 20 go test ./... -v -parallel 1 -timeout 60m

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ go:
 env:
   - CGO_ENABLED=0
 
-script: travis_wait 20 go test ./... -v -parallel 10 -timeout 60m
+script: travis_wait 20 go test ./... -v -parallel 5 -timeout 60m

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/UpCloudLtd/upcloud-go-api
+
+go 1.14
+
+require (
+	github.com/blang/semver v3.5.1+incompatible
+	github.com/hashicorp/go-cleanhttp v0.5.1
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/blang/semver v1.1.0 h1:ol1rO7QQB5uy7umSNV7VAmLugfLRD+17sYJujRNYPhg=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Changes:

* Added `go.mod` and `go.sum` files to make Go module compatible.
* Added `CGO_ENABLED=0` environment to prevent need for GCC compiler.
* Update Go version in `.travis.yml` to 1.13 and 1.14 these are the current stable and previous stable and they both have stable support for Go modules.
