### PR TITLE
Convert DeleteServerAndStorage and GetServers to JSON API

### DIFF
--- a/examples/upcloud-cli/main.go
+++ b/examples/upcloud-cli/main.go
@@ -85,6 +85,14 @@ func deleteServers(s *service.Service) error {
 					fmt.Fprintf(os.Stderr, "Unable to stop server: %#v\n", err)
 					return err
 				}
+				_, err = s.WaitForServerState(&request.WaitForServerStateRequest{
+					UUID:         server.UUID,
+					DesiredState: upcloud.ServerStateStopped,
+				})
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to wait for server to reach desired state: %#v", err)
+					return err
+				}
 			}
 			fmt.Printf("Deleting %s (%s)\n", server.Title, server.UUID)
 			err := s.DeleteServerAndStorages(&request.DeleteServerAndStoragesRequest{

--- a/examples/upcloud-cli/main.go
+++ b/examples/upcloud-cli/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"git.sr.ht/~yoink00/goflenfig"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
+)
+
+var username string
+var password string
+
+func init() {
+	goflenfig.Prefix("UPCLOUD_")
+	goflenfig.StringVar(&username, "username", "", "UpCloud user name")
+	goflenfig.StringVar(&password, "password", "", "UpCloud password")
+}
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	goflenfig.Parse()
+
+	command := flag.Arg(0)
+
+	if len(username) == 0 {
+		fmt.Fprintln(os.Stderr, "Username must be specified")
+		return 1
+	}
+
+	if len(password) == 0 {
+		fmt.Fprintln(os.Stderr, "Password must be specified")
+		return 2
+	}
+
+	fmt.Println("Creating new client")
+	c := client.New(username, password)
+	s := service.New(c)
+
+	switch command {
+	case "deleteservers":
+		if err := deleteServers(s); err != nil {
+			return 1
+		}
+	case "deletestorage":
+		if err := deleteStorage(s); err != nil {
+			return 2
+		}
+	default:
+		fmt.Fprintln(os.Stderr, "Unknown command: ", command)
+		return 99
+	}
+
+	return 0
+}
+
+func deleteServers(s *service.Service) error {
+	fmt.Println("Getting servers")
+	servers, err := s.GetServers()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get servers: %#v\n", err)
+		return err
+	}
+
+	fmt.Printf("Retrieved %d servers\n", len(servers.Servers))
+
+	if len(servers.Servers) > 0 {
+		fmt.Println("Deleting all servers")
+		for _, server := range servers.Servers {
+			if server.State != upcloud.ServerStateStopped {
+				fmt.Printf("Server %s (%s) is not stopped. Stopping\n", server.Title, server.UUID)
+				_, err := s.StopServer(&request.StopServerRequest{
+					UUID:     server.UUID,
+					StopType: request.ServerStopTypeHard,
+				})
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Unable to stop server: %#v\n", err)
+					return err
+				}
+			}
+			fmt.Printf("Deleting %s (%s)\n", server.Title, server.UUID)
+			err := s.DeleteServerAndStorages(&request.DeleteServerAndStoragesRequest{
+				UUID: server.UUID,
+			})
+
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to delete server: %#v\n", err)
+				return err
+			}
+			fmt.Printf("Successfully deleted %s (%s)\n", server.Title, server.UUID)
+		}
+	}
+
+	return nil
+}
+
+func deleteStorage(s *service.Service) error {
+	fmt.Println("Getting storage")
+	storages, err := s.GetStorages(&request.GetStoragesRequest{
+		Access: upcloud.StorageAccessPrivate,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get storages: %#v\n", err)
+		return err
+	}
+
+	fmt.Printf("Retrieved %d storages\n", len(storages.Storages))
+
+	if len(storages.Storages) > 0 {
+		fmt.Println("Deleting all storages")
+		for _, storage := range storages.Storages {
+			err := errors.New("Dummy")
+			for i := 0; err != nil && i < 5; i++ {
+				fmt.Printf("%d: Deleting %s (%s)\n", i, storage.Title, storage.UUID)
+				err = s.DeleteStorage(&request.DeleteStorageRequest{
+					UUID: storage.UUID,
+				})
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to delete storage: %#v (%s)\n", err, err.Error())
+				return err
+			}
+
+			fmt.Printf("Successfully deleted %s (%s)\n", storage.Title, storage.UUID)
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	git.sr.ht/~yoink00/goflenfig v0.1.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/davecgh/go-spew v1.1.1
+	github.com/dnaeon/go-vcr v1.0.1
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	git.sr.ht/~yoink00/goflenfig v0.1.0
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	git.sr.ht/~yoink00/goflenfig v0.1.0
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/UpCloudLtd/upcloud-go-api
 go 1.14
 
 require (
+	git.sr.ht/~yoink00/goflenfig v0.1.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
+github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -21,5 +23,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+git.sr.ht/~yoink00/goflenfig v0.1.0 h1:8RqL7olbs64EHus97F+S1wuPKFco9Av2FmY3Sk6bPoQ=
+git.sr.ht/~yoink00/goflenfig v0.1.0/go.mod h1:+b5SR2TmdQHQ2WqgotlpJEN0xjijoDz6V3pzyfyc6v4=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,5 +40,5 @@ go vet ./...
 staticcheck ./...
 
 # Run tests
-go test ./... -v -failfast -parallel 1 -timeout 60m
+go test ./... -v -failfast -parallel 1 -timeout 60m $*
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,5 +40,5 @@ go vet ./...
 staticcheck ./...
 
 # Run tests
-go test ./... -v -parallel 1 -timeout 60m
+go test ./... -v -failfast -parallel 1 -timeout 60m
 

--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -28,20 +28,27 @@ type Client struct {
 	httpClient *http.Client
 
 	apiVersion string
-	apiBaseUrl string
+	apiBaseURL string
 }
 
 // New creates ands returns a new client configured with the specified user and password
 func New(userName, password string) *Client {
+
+	return NewWithHTTPClient(userName, password, cleanhttp.DefaultClient())
+}
+
+// NewWithHTTPClient creates ands returns a new client configured with the specified user and password and
+// using a supplied `http.Client`.
+func NewWithHTTPClient(userName string, password string, httpClient *http.Client) *Client {
 	client := Client{}
 
 	client.userName = userName
 	client.password = password
-	client.httpClient = cleanhttp.DefaultClient()
+	client.httpClient = httpClient
 	client.SetTimeout(time.Second * DEFAULT_TIMEOUT)
 
 	client.apiVersion = DEFAULT_API_VERSION
-	client.apiBaseUrl = DEFAULT_API_BASEURL
+	client.apiBaseURL = DEFAULT_API_BASEURL
 
 	return &client
 }
@@ -56,9 +63,9 @@ func (c *Client) GetTimeout() time.Duration {
 	return c.httpClient.Timeout
 }
 
-// CreateRequestUrl creates and returns a complete request URL for the specified API location
-func (c *Client) CreateRequestUrl(location string) string {
-	return fmt.Sprintf("%s%s", c.getBaseUrl(), location)
+// CreateRequestURL creates and returns a complete request URL for the specified API location
+func (c *Client) CreateRequestURL(location string) string {
+	return fmt.Sprintf("%s%s", c.getBaseURL(), location)
 }
 
 // PerformGetRequest performs a GET request to the specified URL and returns the response body and eventual errors
@@ -100,7 +107,7 @@ func (c *Client) PerformPostRequest(url string, requestBody []byte) ([]byte, err
 	return c.performRequest(request)
 }
 
-// PerformPostRequest performs a POST request to the specified URL and returns the response body and eventual errors
+// PerformJSONPostRequest performs a POST request to the specified URL and returns the response body and eventual errors
 func (c *Client) PerformJSONPostRequest(url string, requestBody []byte) ([]byte, error) {
 	var bodyReader io.Reader
 
@@ -201,10 +208,10 @@ func (c *Client) performJSONRequest(request *http.Request) ([]byte, error) {
 }
 
 // Returns the base URL to use for API requests
-func (c *Client) getBaseUrl() string {
+func (c *Client) getBaseURL() string {
 	urlVersion, _ := semver.Make(c.apiVersion)
 
-	return fmt.Sprintf("%s/%d.%d", c.apiBaseUrl, urlVersion.Major, urlVersion.Minor)
+	return fmt.Sprintf("%s/%d.%d", c.apiBaseURL, urlVersion.Major, urlVersion.Minor)
 }
 
 // Parses the response and returns either the response body or an error

--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -91,13 +91,30 @@ func (c *Client) PerformPostRequest(url string, requestBody []byte) ([]byte, err
 		bodyReader = bytes.NewBuffer(requestBody)
 	}
 
-	request, err := http.NewRequest("POST", url, bodyReader)
+	request, err := http.NewRequest(http.MethodPost, url, bodyReader)
 
 	if err != nil {
 		return nil, err
 	}
 
 	return c.performRequest(request)
+}
+
+// PerformPostRequest performs a POST request to the specified URL and returns the response body and eventual errors
+func (c *Client) PerformJSONPostRequest(url string, requestBody []byte) ([]byte, error) {
+	var bodyReader io.Reader
+
+	if requestBody != nil {
+		bodyReader = bytes.NewBuffer(requestBody)
+	}
+
+	request, err := http.NewRequest(http.MethodPost, url, bodyReader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c.performJSONRequest(request)
 }
 
 // PerformPutRequest performs a PUT request to the specified URL and returns the response body and eventual errors

--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -63,13 +63,24 @@ func (c *Client) CreateRequestUrl(location string) string {
 
 // PerformGetRequest performs a GET request to the specified URL and returns the response body and eventual errors
 func (c *Client) PerformGetRequest(url string) ([]byte, error) {
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 
 	if err != nil {
 		return nil, err
 	}
 
 	return c.performRequest(request)
+}
+
+// PerformJSONGetRequest performs a GET request to the specified URL and returns the response body and eventual errors
+func (c *Client) PerformJSONGetRequest(url string) ([]byte, error) {
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c.performJSONRequest(request)
 }
 
 // PerformPostRequest performs a POST request to the specified URL and returns the response body and eventual errors
@@ -108,13 +119,25 @@ func (c *Client) PerformPutRequest(url string, requestBody []byte) ([]byte, erro
 
 // PerformDeleteRequest performs a DELETE request to the specified URL and returns the response body and eventual errors
 func (c *Client) PerformDeleteRequest(url string) error {
-	request, err := http.NewRequest("DELETE", url, nil)
+	request, err := http.NewRequest(http.MethodDelete, url, nil)
 
 	if err != nil {
 		return err
 	}
 
 	_, err = c.performRequest(request)
+	return err
+}
+
+// PerformJSONDeleteRequest performs a DELETE request to the specified URL and returns the response body and eventual errors
+func (c *Client) PerformJSONDeleteRequest(url string) error {
+	request, err := http.NewRequest(http.MethodDelete, url, nil)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.performJSONRequest(request)
 	return err
 }
 
@@ -127,9 +150,30 @@ func (c *Client) addRequestHeaders(request *http.Request) *http.Request {
 	return request
 }
 
+// Adds common headers to the specified request
+func (c *Client) addJSONRequestHeaders(request *http.Request) *http.Request {
+	request.SetBasicAuth(c.userName, c.password)
+	request.Header.Add("Accept", "application/json")
+	request.Header.Add("Content-Type", "application/json")
+
+	return request
+}
+
 // Performs the specified HTTP request and returns the response through handleResponse()
 func (c *Client) performRequest(request *http.Request) ([]byte, error) {
 	c.addRequestHeaders(request)
+	response, err := c.httpClient.Do(request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return handleResponse(response)
+}
+
+// Performs the specified HTTP request and returns the response through handleResponse()
+func (c *Client) performJSONRequest(request *http.Request) ([]byte, error) {
+	c.addJSONRequestHeaders(request)
 	response, err := c.httpClient.Do(request)
 
 	if err != nil {

--- a/upcloud/error.go
+++ b/upcloud/error.go
@@ -12,14 +12,16 @@ type Error struct {
 }
 
 func (e *Error) UnmarshalJSON(b []byte) error {
-	var v map[string]map[string]string
+	type localError Error
+	v := struct {
+		Error localError `json:"error"`
+	}{}
 	err := json.Unmarshal(b, &v)
 	if err != nil {
 		return err
 	}
 
-	e.ErrorCode = v["error"]["error_code"]
-	e.ErrorMessage = v["error"]["error_message"]
+	(*e) = Error(v.Error)
 
 	return nil
 }

--- a/upcloud/error.go
+++ b/upcloud/error.go
@@ -12,8 +12,6 @@ type Error struct {
 }
 
 func (e *Error) UnmarshalJSON(b []byte) error {
-	fmt.Println("Unmarshalling: ", string(b))
-
 	var v map[string]map[string]string
 	err := json.Unmarshal(b, &v)
 	if err != nil {

--- a/upcloud/error.go
+++ b/upcloud/error.go
@@ -1,11 +1,29 @@
 package upcloud
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Error represents an error
 type Error struct {
-	ErrorCode    string `xml:"error_code"`
-	ErrorMessage string `xml:"error_message"`
+	ErrorCode    string `xml:"error_code" json:"error_code"`
+	ErrorMessage string `xml:"error_message" json:"error_message"`
+}
+
+func (e *Error) UnmarshalJSON(b []byte) error {
+	fmt.Println("Unmarshalling: ", string(b))
+
+	var v map[string]map[string]string
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	e.ErrorCode = v["error"]["error_code"]
+	e.ErrorMessage = v["error"]["error_message"]
+
+	return nil
 }
 
 // Error implements the Error interface

--- a/upcloud/error_test.go
+++ b/upcloud/error_test.go
@@ -1,0 +1,26 @@
+package upcloud
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUnmarshalFirewallRules tests the FirewallRules and FirewallRule are unmarshaled correctly
+func TestError(t *testing.T) {
+	originalJSON := `
+        {
+            "error": {
+              "error_message": "The server 00af0f73-7082-4283-b925-811d1585774b does not exist.",
+              "error_code": "SERVER_NOT_FOUND"
+            }
+        }
+    `
+
+	e := Error{}
+	err := json.Unmarshal([]byte(originalJSON), &e)
+	assert.NoError(t, err)
+	assert.Equal(t, "The server 00af0f73-7082-4283-b925-811d1585774b does not exist.", e.ErrorMessage)
+	assert.Equal(t, "SERVER_NOT_FOUND", e.ErrorCode)
+}

--- a/upcloud/ip_address.go
+++ b/upcloud/ip_address.go
@@ -16,11 +16,11 @@ type IPAddresses struct {
 
 // IPAddress represents an IP address
 type IPAddress struct {
-	Access  string `xml:"access"`
-	Address string `xml:"address"`
-	Family  string `xml:"family"`
+	Access  string `xml:"access" json:"access"`
+	Address string `xml:"address" json:"address"`
+	Family  string `xml:"family" json:"family"`
 	// TODO: Convert to boolean
-	PartOfPlan string `xml:"part_of_plan"`
-	PTRRecord  string `xml:"ptr_record"`
-	ServerUUID string `xml:"server"`
+	PartOfPlan string `xml:"part_of_plan" json:"part_of_plan"`
+	PTRRecord  string `xml:"ptr_record" json:"ptr_record"`
+	ServerUUID string `xml:"server" json:"server"`
 }

--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -96,11 +96,37 @@ func (r *CreateServerRequest) RequestURL() string {
 	return "/server"
 }
 
+type SSHKeySlice []string
+
+func (s *SSHKeySlice) UnmarshalJSON(b []byte) error {
+	v := struct {
+		SSHKey []string `json:"ssh_key"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*s) = v.SSHKey
+
+	return nil
+}
+
+func (s SSHKeySlice) MarshalJSON() ([]byte, error) {
+	v := struct {
+		SSHKey []string `json:"ssh_key"`
+	}{}
+
+	v.SSHKey = s
+
+	return json.Marshal(v)
+}
+
 // LoginUser represents the login_user block when creating a new server
 type LoginUser struct {
-	CreatePassword string   `xml:"create_password,omitempty" json:"create_password,omitempty"`
-	Username       string   `xml:"username,omitempty" json:"username,omitempty"`
-	SSHKeys        []string `xml:"ssh_keys>ssh_key,omitempty" json:"ssh_keys"`
+	CreatePassword string      `xml:"create_password,omitempty" json:"create_password,omitempty"`
+	Username       string      `xml:"username,omitempty" json:"username,omitempty"`
+	SSHKeys        SSHKeySlice `xml:"ssh_keys>ssh_key,omitempty" json:"ssh_keys"`
 }
 
 // CreateServerIPAddress represents an IP address for a CreateServerRequest

--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"strings"
@@ -32,30 +33,62 @@ func (r *GetServerDetailsRequest) RequestURL() string {
 	return fmt.Sprintf("/server/%s", r.UUID)
 }
 
+type CreateServerIPAddressSlice []CreateServerIPAddress
+
+func (s CreateServerIPAddressSlice) MarshalJSON() ([]byte, error) {
+	v := struct {
+		IPAddress []CreateServerIPAddress `json:"ip_address"`
+	}{}
+	v.IPAddress = s
+
+	return json.Marshal(v)
+}
+
+type CreateServerStorageDeviceSlice []upcloud.CreateServerStorageDevice
+
+func (s CreateServerStorageDeviceSlice) MarshalJSON() ([]byte, error) {
+	v := struct {
+		StorageDevice []upcloud.CreateServerStorageDevice `json:"storage_device"`
+	}{}
+	v.StorageDevice = s
+
+	return json.Marshal(v)
+}
+
 // CreateServerRequest represents a request for creating a new server
 type CreateServerRequest struct {
-	XMLName xml.Name `xml:"server"`
+	XMLName xml.Name `xml:"server" json:"-"`
 
-	AvoidHost  string `xml:"avoid_host,omitempty"`
-	BootOrder  string `xml:"boot_order,omitempty"`
-	CoreNumber int    `xml:"core_number,omitempty"`
+	AvoidHost  string `xml:"avoid_host,omitempty" json:"avoid_host,omitempty"`
+	BootOrder  string `xml:"boot_order,omitempty" json:"boot_order,omitempty"`
+	CoreNumber int    `xml:"core_number,omitempty" json:"core_number,omitempty"`
 	// TODO: Convert to boolean
-	Firewall         string                              `xml:"firewall,omitempty"`
-	Hostname         string                              `xml:"hostname"`
-	IPAddresses      []CreateServerIPAddress             `xml:"ip_addresses>ip_address"`
-	LoginUser        *LoginUser                          `xml:"login_user,omitempty"`
-	MemoryAmount     int                                 `xml:"memory_amount,omitempty"`
-	PasswordDelivery string                              `xml:"password_delivery,omitempty"`
-	Plan             string                              `xml:"plan,omitempty"`
-	StorageDevices   []upcloud.CreateServerStorageDevice `xml:"storage_devices>storage_device"`
-	TimeZone         string                              `xml:"timezone,omitempty"`
-	Title            string                              `xml:"title"`
-	UserData         string                              `xml:"user_data,omitempty"`
-	VideoModel       string                              `xml:"video_model,omitempty"`
+	Firewall         string                         `xml:"firewall,omitempty" json:"firewall,omitempty"`
+	Hostname         string                         `xml:"hostname" json:"hostname"`
+	IPAddresses      CreateServerIPAddressSlice     `xml:"ip_addresses>ip_address" json:"ip_addresses"`
+	LoginUser        *LoginUser                     `xml:"login_user,omitempty" json:"login_user,omitempty"`
+	MemoryAmount     int                            `xml:"memory_amount,omitempty" json:"memory_amount,omitempty"`
+	PasswordDelivery string                         `xml:"password_delivery,omitempty" json:"password_delivery,omitempty"`
+	Plan             string                         `xml:"plan,omitempty" json:"plan,omitempty"`
+	StorageDevices   CreateServerStorageDeviceSlice `xml:"storage_devices>storage_device" json:"storage_devices"`
+	TimeZone         string                         `xml:"timezone,omitempty" json:"timezone,omitempty"`
+	Title            string                         `xml:"title" json:"title"`
+	UserData         string                         `xml:"user_data,omitempty" json:"user_data,omitempty"`
+	VideoModel       string                         `xml:"video_model,omitempty" json:"video_model,omitempty"`
 	// TODO: Convert to boolean
-	VNC         string `xml:"vnc,omitempty"`
-	VNCPassword string `xml:"vnc_password,omitempty"`
-	Zone        string `xml:"zone"`
+	VNC         string `xml:"vnc,omitempty" json:"vnc,omitempty"`
+	VNCPassword string `xml:"vnc_password,omitempty" json:"vnc_password,omitempty"`
+	Zone        string `xml:"zone" json:"zone"`
+}
+
+func (r CreateServerRequest) MarshalJSON() ([]byte, error) {
+	type localCreateServerRequest CreateServerRequest
+	v := struct {
+		Server localCreateServerRequest `json:"server"`
+	}{}
+	v.Server = localCreateServerRequest(r)
+
+	return json.Marshal(&v)
 }
 
 // RequestURL implements the Request interface
@@ -65,15 +98,15 @@ func (r *CreateServerRequest) RequestURL() string {
 
 // LoginUser represents the login_user block when creating a new server
 type LoginUser struct {
-	CreatePassword string   `xml:"create_password,omitempty"`
-	Username       string   `xml:"username,omitempty"`
-	SSHKeys        []string `xml:"ssh_keys>ssh_key,omitempty"`
+	CreatePassword string   `xml:"create_password,omitempty" json:"create_password,omitempty"`
+	Username       string   `xml:"username,omitempty" json:"username,omitempty"`
+	SSHKeys        []string `xml:"ssh_keys>ssh_key,omitempty" json:"ssh_keys"`
 }
 
 // CreateServerIPAddress represents an IP address for a CreateServerRequest
 type CreateServerIPAddress struct {
-	Access string `xml:"access"`
-	Family string `xml:"family"`
+	Access string `xml:"access" json:"access"`
+	Family string `xml:"family" json:"family"`
 }
 
 // WaitForServerStateRequest represents a request to wait for a server to enter or exit a specific state

--- a/upcloud/request/server_test.go
+++ b/upcloud/request/server_test.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"testing"
 	"time"
@@ -57,10 +58,53 @@ func TestCreateServerRequest(t *testing.T) {
 		},
 	}
 
-	expectedXML := "<server><hostname>debian.example.com</hostname><ip_addresses><ip_address><access>private</access><family>IPv4</family></ip_address><ip_address><access>public</access><family>IPv4</family></ip_address><ip_address><access>public</access><family>IPv6</family></ip_address></ip_addresses><login_user><create_password>no</create_password><ssh_keys><ssh_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCWf2MmpHweXCNUcW91PWZR5UqOkydBr1Gi1xDI16IW4JndMYkH9OF0sWvPz03kfY6NbcHY0bed1Q8BpAC//WfLltuvjrzk33IoFJZ2Ai+4fVdkevkf7pBeSvzdXSyKAT+suHrp/2Qu5hewIUdDCp+znkwyypIJ/C2hDphwbLR3QquOfn6KyKMPZC4my8dFvLxESI0UqeripaBHUGcvNG2LL563hXmWzUu/cyqCpg5IBzpj/ketg8m1KBO7U0dimIAczuxfHk3kp9bwOFquWA2vSFNuVkr8oavk36pHkU88qojYNEy/zUTINE0w6CE/EbDkQVDZEGgDtAkq4jL+4MPV negge@palinski</ssh_key><ssh_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJfx4OmD8D6mnPA0BPk2DVlbggEkMvB2cecSttauZuaYX7Vju6PvG+kXrUbTvO09oLQMoNYAk3RinqQLXo9eF7bzZIsgB4ZmKGau84kOpYjguhimkKtZiVTKF53G2pbnpiZUN9wfy3xK2mt/MkacjZ1Tp7lAgRGTfWDoTfQa88kzOJGNPWXd12HIvFtd/1KoS9vm5O0nDLV+5zSBLxEYNDmBlIGu1Y3XXle5ygL1BhfGvqOQnv/TdRZcrOgVGWHADvwEid91/+IycLNMc37uP7TdS6vOihFBMytfmFXAqt4+3AzYNmyc+R392RorFzobZ1UuEFm3gUod2Wvj8pY8d/ negge@palinski</ssh_key></ssh_keys></login_user><password_delivery>none</password_delivery><storage_devices><storage_device><action>clone</action><storage>01000000-0000-4000-8000-000030060200</storage><title>disk1</title><size>30</size><tier>maxiops</tier></storage_device></storage_devices><title>Integration test server #1</title><zone>fi-hel2</zone></server>"
-	actualXML, err := xml.Marshal(&request)
+	expectedJSON := `
+	{
+      "server": {
+        "hostname": "debian.example.com",
+        "ip_addresses": {
+          "ip_address": [
+            {
+              "access": "private",
+              "family": "IPv4"
+            },
+            {
+              "access": "public",
+              "family": "IPv4"
+            },
+            {
+              "access": "public",
+              "family": "IPv6"
+            }
+          ]
+        },
+        "login_user": {
+          "create_password": "no",
+          "ssh_keys": [
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCWf2MmpHweXCNUcW91PWZR5UqOkydBr1Gi1xDI16IW4JndMYkH9OF0sWvPz03kfY6NbcHY0bed1Q8BpAC//WfLltuvjrzk33IoFJZ2Ai+4fVdkevkf7pBeSvzdXSyKAT+suHrp/2Qu5hewIUdDCp+znkwyypIJ/C2hDphwbLR3QquOfn6KyKMPZC4my8dFvLxESI0UqeripaBHUGcvNG2LL563hXmWzUu/cyqCpg5IBzpj/ketg8m1KBO7U0dimIAczuxfHk3kp9bwOFquWA2vSFNuVkr8oavk36pHkU88qojYNEy/zUTINE0w6CE/EbDkQVDZEGgDtAkq4jL+4MPV negge@palinski",
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJfx4OmD8D6mnPA0BPk2DVlbggEkMvB2cecSttauZuaYX7Vju6PvG+kXrUbTvO09oLQMoNYAk3RinqQLXo9eF7bzZIsgB4ZmKGau84kOpYjguhimkKtZiVTKF53G2pbnpiZUN9wfy3xK2mt/MkacjZ1Tp7lAgRGTfWDoTfQa88kzOJGNPWXd12HIvFtd/1KoS9vm5O0nDLV+5zSBLxEYNDmBlIGu1Y3XXle5ygL1BhfGvqOQnv/TdRZcrOgVGWHADvwEid91/+IycLNMc37uP7TdS6vOihFBMytfmFXAqt4+3AzYNmyc+R392RorFzobZ1UuEFm3gUod2Wvj8pY8d/ negge@palinski"
+          ]
+        },
+        "password_delivery": "none",
+        "storage_devices": {
+          "storage_device": [
+            {
+              "action": "clone",
+              "storage": "01000000-0000-4000-8000-000030060200",
+              "title": "disk1",
+              "size": 30,
+              "tier": "maxiops"
+            }
+          ]
+        },
+        "title": "Integration test server #1",
+        "zone": "fi-hel2"
+      }
+    }
+	`
+	actualJSON, err := json.Marshal(&request)
 	assert.Nil(t, err)
-	assert.Equal(t, expectedXML, string(actualXML))
+	assert.JSONEq(t, expectedJSON, string(actualJSON))
 	assert.Equal(t, "/server", request.RequestURL())
 }
 

--- a/upcloud/request/server_test.go
+++ b/upcloud/request/server_test.go
@@ -80,10 +80,12 @@ func TestCreateServerRequest(t *testing.T) {
         },
         "login_user": {
           "create_password": "no",
-          "ssh_keys": [
-            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCWf2MmpHweXCNUcW91PWZR5UqOkydBr1Gi1xDI16IW4JndMYkH9OF0sWvPz03kfY6NbcHY0bed1Q8BpAC//WfLltuvjrzk33IoFJZ2Ai+4fVdkevkf7pBeSvzdXSyKAT+suHrp/2Qu5hewIUdDCp+znkwyypIJ/C2hDphwbLR3QquOfn6KyKMPZC4my8dFvLxESI0UqeripaBHUGcvNG2LL563hXmWzUu/cyqCpg5IBzpj/ketg8m1KBO7U0dimIAczuxfHk3kp9bwOFquWA2vSFNuVkr8oavk36pHkU88qojYNEy/zUTINE0w6CE/EbDkQVDZEGgDtAkq4jL+4MPV negge@palinski",
-            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJfx4OmD8D6mnPA0BPk2DVlbggEkMvB2cecSttauZuaYX7Vju6PvG+kXrUbTvO09oLQMoNYAk3RinqQLXo9eF7bzZIsgB4ZmKGau84kOpYjguhimkKtZiVTKF53G2pbnpiZUN9wfy3xK2mt/MkacjZ1Tp7lAgRGTfWDoTfQa88kzOJGNPWXd12HIvFtd/1KoS9vm5O0nDLV+5zSBLxEYNDmBlIGu1Y3XXle5ygL1BhfGvqOQnv/TdRZcrOgVGWHADvwEid91/+IycLNMc37uP7TdS6vOihFBMytfmFXAqt4+3AzYNmyc+R392RorFzobZ1UuEFm3gUod2Wvj8pY8d/ negge@palinski"
-          ]
+          "ssh_keys": {
+			  "ssh_key": [
+                "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCWf2MmpHweXCNUcW91PWZR5UqOkydBr1Gi1xDI16IW4JndMYkH9OF0sWvPz03kfY6NbcHY0bed1Q8BpAC//WfLltuvjrzk33IoFJZ2Ai+4fVdkevkf7pBeSvzdXSyKAT+suHrp/2Qu5hewIUdDCp+znkwyypIJ/C2hDphwbLR3QquOfn6KyKMPZC4my8dFvLxESI0UqeripaBHUGcvNG2LL563hXmWzUu/cyqCpg5IBzpj/ketg8m1KBO7U0dimIAczuxfHk3kp9bwOFquWA2vSFNuVkr8oavk36pHkU88qojYNEy/zUTINE0w6CE/EbDkQVDZEGgDtAkq4jL+4MPV negge@palinski",
+				"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJfx4OmD8D6mnPA0BPk2DVlbggEkMvB2cecSttauZuaYX7Vju6PvG+kXrUbTvO09oLQMoNYAk3RinqQLXo9eF7bzZIsgB4ZmKGau84kOpYjguhimkKtZiVTKF53G2pbnpiZUN9wfy3xK2mt/MkacjZ1Tp7lAgRGTfWDoTfQa88kzOJGNPWXd12HIvFtd/1KoS9vm5O0nDLV+5zSBLxEYNDmBlIGu1Y3XXle5ygL1BhfGvqOQnv/TdRZcrOgVGWHADvwEid91/+IycLNMc37uP7TdS6vOihFBMytfmFXAqt4+3AzYNmyc+R392RorFzobZ1UuEFm3gUod2Wvj8pY8d/ negge@palinski"
+			  ]
+		  }
         },
         "password_delivery": "none",
         "storage_devices": {

--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -75,7 +75,7 @@ type Server struct {
 	License      float64  `xml:"license" json:"license"`
 	MemoryAmount int      `xml:"memory_amount" json:"memory_amount,string"`
 	Plan         string   `xml:"plan" json:"plan"`
-	Progress     int      `xml:"progress" json:"progress"`
+	Progress     int      `xml:"progress" json:"progress,string"`
 	State        string   `xml:"state" json:"state"`
 	Tags         TagSlice `xml:"tags>tag" json:"tags"`
 	Title        string   `xml:"title" json:"title"`
@@ -83,23 +83,71 @@ type Server struct {
 	Zone         string   `xml:"zone" json:"zone"`
 }
 
+type IPAddressSlice []IPAddress
+
+func (i *IPAddressSlice) UnmarshalJSON(b []byte) error {
+	v := struct {
+		IPAddresses []IPAddress `json:"ip_address"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*i) = v.IPAddresses
+
+	return nil
+}
+
+type ServerStorageDeviceSlice []ServerStorageDevice
+
+func (s *ServerStorageDeviceSlice) UnmarshalJSON(b []byte) error {
+	v := struct {
+		StorageDevices []ServerStorageDevice `json:"storage_device"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*s) = v.StorageDevices
+
+	return nil
+}
+
 // ServerDetails represents details about a server
 type ServerDetails struct {
 	Server
 
-	BootOrder  string `xml:"boot_order"`
-	CoreNumber int    `xml:"core_number"`
+	BootOrder  string `xml:"boot_order" json:"boot_order"`
+	CoreNumber int    `xml:"core_number" json:"core_number,string"`
 	// TODO: Convert to boolean
-	Firewall       string                `xml:"firewall"`
-	Host           int                   `xml:"host"`
-	IPAddresses    []IPAddress           `xml:"ip_addresses>ip_address"`
-	NICModel       string                `xml:"nic_model"`
-	StorageDevices []ServerStorageDevice `xml:"storage_devices>storage_device"`
-	Timezone       string                `xml:"timezone"`
-	VideoModel     string                `xml:"video_model"`
+	Firewall       string                   `xml:"firewall" json:"firewall"`
+	Host           int                      `xml:"host" json:"host"`
+	IPAddresses    IPAddressSlice           `xml:"ip_addresses>ip_address" json:"ip_addresses"`
+	NICModel       string                   `xml:"nic_model" json:"nic_model"`
+	StorageDevices ServerStorageDeviceSlice `xml:"storage_devices>storage_device" json:"storage_devices"`
+	Timezone       string                   `xml:"timezone" json:"timezone"`
+	VideoModel     string                   `xml:"video_model" json:"video_model"`
 	// TODO: Convert to boolean
-	VNC         string `xml:"vnc"`
-	VNCHost     string `xml:"vnc_host"`
-	VNCPassword string `xml:"vnc_password"`
-	VNCPort     int    `xml:"vnc_port"`
+	VNC         string `xml:"vnc" json:"vnc"`
+	VNCHost     string `xml:"vnc_host" json:"vnc_host"`
+	VNCPassword string `xml:"vnc_password" json:"vnc_password"`
+	VNCPort     int    `xml:"vnc_port" json:"vnc_port"`
+}
+
+func (s *ServerDetails) UnmarshalJSON(b []byte) error {
+	type localServerDetails ServerDetails
+
+	v := struct {
+		ServerDetails localServerDetails `json:"server"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*s) = ServerDetails(v.ServerDetails)
+
+	return nil
 }

--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -1,5 +1,9 @@
 package upcloud
 
+import (
+	"encoding/json"
+)
+
 // Constants
 const (
 	ServerStateStarted     = "started"
@@ -27,22 +31,56 @@ type ServerConfiguration struct {
 
 // Servers represents a /server response
 type Servers struct {
-	Servers []Server `xml:"server"`
+	Servers []Server `xml:"server" json:"servers"`
+}
+
+func (s *Servers) UnmarshalJSON(b []byte) error {
+	type serverWrapper struct {
+		Servers []Server `json:"server"`
+	}
+
+	v := struct {
+		Servers serverWrapper `json:"servers"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	s.Servers = v.Servers.Servers
+
+	return nil
+}
+
+type TagsType []string
+
+func (t *TagsType) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Tags []string `json:"tag"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*t) = v.Tags
+
+	return nil
 }
 
 // Server represents a server
 type Server struct {
-	CoreNumber   int      `xml:"core_number"`
-	Hostname     string   `xml:"hostname"`
-	License      float64  `xml:"license"`
-	MemoryAmount int      `xml:"memory_amount"`
-	Plan         string   `xml:"plan"`
-	Progress     int      `xml:"progress"`
-	State        string   `xml:"state"`
-	Tags         []string `xml:"tags>tag"`
-	Title        string   `xml:"title"`
-	UUID         string   `xml:"uuid"`
-	Zone         string   `xml:"zone"`
+	CoreNumber   int      `xml:"core_number" json:"core_number,string"`
+	Hostname     string   `xml:"hostname" json:"hostname"`
+	License      float64  `xml:"license" json:"license"`
+	MemoryAmount int      `xml:"memory_amount" json:"memory_amount,string"`
+	Plan         string   `xml:"plan" json:"plan"`
+	Progress     int      `xml:"progress" json:"progress"`
+	State        string   `xml:"state" json:"state"`
+	Tags         TagsType `xml:"tags>tag" json:"tags"`
+	Title        string   `xml:"title" json:"title"`
+	UUID         string   `xml:"uuid" json:"uuid"`
+	Zone         string   `xml:"zone" json:"zone"`
 }
 
 // ServerDetails represents details about a server

--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -52,9 +52,9 @@ func (s *Servers) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type TagsType []string
+type TagSlice []string
 
-func (t *TagsType) UnmarshalJSON(b []byte) error {
+func (t *TagSlice) UnmarshalJSON(b []byte) error {
 	v := struct {
 		Tags []string `json:"tag"`
 	}{}
@@ -77,7 +77,7 @@ type Server struct {
 	Plan         string   `xml:"plan" json:"plan"`
 	Progress     int      `xml:"progress" json:"progress"`
 	State        string   `xml:"state" json:"state"`
-	Tags         TagsType `xml:"tags>tag" json:"tags"`
+	Tags         TagSlice `xml:"tags>tag" json:"tags"`
 	Title        string   `xml:"title" json:"title"`
 	UUID         string   `xml:"uuid" json:"uuid"`
 	Zone         string   `xml:"zone" json:"zone"`

--- a/upcloud/server_test.go
+++ b/upcloud/server_test.go
@@ -48,7 +48,7 @@ func TestUnmarshalServers(t *testing.T) {
                         "license": 0,
                         "memory_amount": "1024",
                         "plan": "1xCPU-1GB",
-                        "progress": 95,
+                        "progress": "95",
                         "state": "maintenance",
                         "tags": {
                             "tag": []

--- a/upcloud/server_test.go
+++ b/upcloud/server_test.go
@@ -1,6 +1,7 @@
 package upcloud
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"testing"
 
@@ -37,26 +38,32 @@ func TestUnmarshalServerConfiguratons(t *testing.T) {
 
 // TestUnmarshalServers tests that Servers and Server are unmarshaled correctly
 func TestUnmarshalServers(t *testing.T) {
-	originalXML := `<?xml version="1.0" encoding="utf-8"?>
-<servers>
-    <server>
-        <core_number>1</core_number>
-        <hostname>foo</hostname>
-        <license>0</license>
-        <memory_amount>1024</memory_amount>
-        <plan>1xCPU-1GB</plan>
-        <progress>95</progress>
-        <state>maintenance</state>
-        <tags>
-    </tags>
-        <title>foo.example.com</title>
-        <uuid>009114f1-cd89-4202-b057-5680eb6ba428</uuid>
-        <zone>uk-lon1</zone>
-    </server>
-</servers>`
+	originalJSON := `
+        {
+            "servers" : {
+                "server" : [
+                    {
+                        "core_number" : "1",
+                        "hostname": "foo",
+                        "license": 0,
+                        "memory_amount": "1024",
+                        "plan": "1xCPU-1GB",
+                        "progress": 95,
+                        "state": "maintenance",
+                        "tags": {
+                            "tag": []
+                        },
+                        "title": "foo.example.com",
+                        "uuid": "009114f1-cd89-4202-b057-5680eb6ba428",
+                        "zone": "uk-lon1"
+                    }
+                ]
+            }
+        }
+    `
 
 	servers := Servers{}
-	err := xml.Unmarshal([]byte(originalXML), &servers)
+	err := json.Unmarshal([]byte(originalJSON), &servers)
 	assert.Nil(t, err)
 	assert.Len(t, servers.Servers, 1)
 

--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -143,14 +143,17 @@ func (s *Service) GetServerDetails(r *request.GetServerDetailsRequest) (*upcloud
 // CreateServer creates a server and returns the server details for the newly created server
 func (s *Service) CreateServer(r *request.CreateServerRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
-	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	requestBody, _ := json.Marshal(r)
+	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
 
 	if err != nil {
-		return nil, parseServiceError(err)
+		return nil, parseJSONServiceError(err)
 	}
 
-	xml.Unmarshal(response, &serverDetails)
+	err = json.Unmarshal(response, &serverDetails)
+	if err != nil {
+		return nil, err
+	}
 
 	return &serverDetails, nil
 }

--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -114,7 +114,7 @@ func (s *Service) GetServers() (*upcloud.Servers, error) {
 	response, err := s.basicJSONGetRequest("/server")
 
 	if err != nil {
-		return nil, parseServiceError(err)
+		return nil, parseJSONServiceError(err)
 	}
 
 	fmt.Println(string(response))
@@ -280,7 +280,7 @@ func (s *Service) DeleteServerAndStorages(r *request.DeleteServerAndStoragesRequ
 	err := s.client.PerformJSONDeleteRequest(s.client.CreateRequestUrl(r.RequestURL()))
 
 	if err != nil {
-		return parseServiceError(err)
+		return parseJSONServiceError(err)
 	}
 
 	return nil
@@ -738,6 +738,20 @@ func parseServiceError(err error) error {
 		serviceError := upcloud.Error{}
 		responseBody := clientError.ResponseBody
 		xml.Unmarshal(responseBody, &serviceError)
+
+		return &serviceError
+	}
+
+	return err
+}
+
+// Parses an error returned from the client into a service error object
+func parseJSONServiceError(err error) error {
+	// Parse service errors
+	if clientError, ok := err.(*client.Error); ok {
+		serviceError := upcloud.Error{}
+		responseBody := clientError.ResponseBody
+		json.Unmarshal(responseBody, &serviceError)
 
 		return &serviceError
 	}

--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -145,7 +145,7 @@ func (s *Service) GetServerDetails(r *request.GetServerDetailsRequest) (*upcloud
 func (s *Service) CreateServer(r *request.CreateServerRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := json.Marshal(r)
-	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseJSONServiceError(err)
@@ -160,7 +160,7 @@ func (s *Service) CreateServer(r *request.CreateServerRequest) (*upcloud.ServerD
 }
 
 func (s *Service) CreateServerOption1(json string) (string, error) {
-	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestUrl("/server"), []byte(json))
+	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestURL("/server"), []byte(json))
 
 	if err != nil {
 		return "", errors.New(string(err.(*client.Error).ResponseBody))
@@ -212,7 +212,7 @@ func (s *Service) StartServer(r *request.StartServerRequest) (*upcloud.ServerDet
 	s.client.SetTimeout(r.Timeout)
 
 	serverDetails := upcloud.ServerDetails{}
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), nil)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), nil)
 
 	// Restore previous timout
 	s.client.SetTimeout(prevTimeout)
@@ -233,7 +233,7 @@ func (s *Service) StopServer(r *request.StopServerRequest) (*upcloud.ServerDetai
 
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -251,7 +251,7 @@ func (s *Service) RestartServer(r *request.RestartServerRequest) (*upcloud.Serve
 
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -267,7 +267,7 @@ func (s *Service) RestartServer(r *request.RestartServerRequest) (*upcloud.Serve
 func (s *Service) ModifyServer(r *request.ModifyServerRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPutRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPutRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -280,7 +280,7 @@ func (s *Service) ModifyServer(r *request.ModifyServerRequest) (*upcloud.ServerD
 
 // DeleteServer deletes the specified server
 func (s *Service) DeleteServer(r *request.DeleteServerRequest) error {
-	err := s.client.PerformDeleteRequest(s.client.CreateRequestUrl(r.RequestURL()))
+	err := s.client.PerformDeleteRequest(s.client.CreateRequestURL(r.RequestURL()))
 
 	if err != nil {
 		return parseServiceError(err)
@@ -291,7 +291,7 @@ func (s *Service) DeleteServer(r *request.DeleteServerRequest) error {
 
 // DeleteServerAndStorages deletes the specified server and all attached storages
 func (s *Service) DeleteServerAndStorages(r *request.DeleteServerAndStoragesRequest) error {
-	err := s.client.PerformJSONDeleteRequest(s.client.CreateRequestUrl(r.RequestURL()))
+	err := s.client.PerformJSONDeleteRequest(s.client.CreateRequestURL(r.RequestURL()))
 
 	if err != nil {
 		return parseJSONServiceError(err)
@@ -303,7 +303,7 @@ func (s *Service) DeleteServerAndStorages(r *request.DeleteServerAndStoragesRequ
 // TagServer tags a server with with one or more tags
 func (s *Service) TagServer(r *request.TagServerRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), nil)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), nil)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -317,7 +317,7 @@ func (s *Service) TagServer(r *request.TagServerRequest) (*upcloud.ServerDetails
 // UntagServer removes one or more tags from a server
 func (s *Service) UntagServer(r *request.UntagServerRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), nil)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), nil)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -332,7 +332,7 @@ func (s *Service) UntagServer(r *request.UntagServerRequest) (*upcloud.ServerDet
 func (s *Service) CreateTag(r *request.CreateTagRequest) (*upcloud.Tag, error) {
 	tagDetails := upcloud.Tag{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -347,7 +347,7 @@ func (s *Service) CreateTag(r *request.CreateTagRequest) (*upcloud.Tag, error) {
 func (s *Service) ModifyTag(r *request.ModifyTagRequest) (*upcloud.Tag, error) {
 	tagDetails := upcloud.Tag{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPutRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPutRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -360,7 +360,7 @@ func (s *Service) ModifyTag(r *request.ModifyTagRequest) (*upcloud.Tag, error) {
 
 // DeleteTag deletes the specified tag
 func (s *Service) DeleteTag(r *request.DeleteTagRequest) error {
-	err := s.client.PerformDeleteRequest(s.client.CreateRequestUrl(r.RequestURL()))
+	err := s.client.PerformDeleteRequest(s.client.CreateRequestURL(r.RequestURL()))
 
 	if err != nil {
 		return parseServiceError(err)
@@ -401,7 +401,7 @@ func (s *Service) GetStorageDetails(r *request.GetStorageDetailsRequest) (*upclo
 func (s *Service) CreateStorage(r *request.CreateStorageRequest) (*upcloud.StorageDetails, error) {
 	storageDetails := upcloud.StorageDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -416,7 +416,7 @@ func (s *Service) CreateStorage(r *request.CreateStorageRequest) (*upcloud.Stora
 func (s *Service) ModifyStorage(r *request.ModifyStorageRequest) (*upcloud.StorageDetails, error) {
 	storageDetails := upcloud.StorageDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPutRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPutRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -431,7 +431,7 @@ func (s *Service) ModifyStorage(r *request.ModifyStorageRequest) (*upcloud.Stora
 func (s *Service) AttachStorage(r *request.AttachStorageRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -446,7 +446,7 @@ func (s *Service) AttachStorage(r *request.AttachStorageRequest) (*upcloud.Serve
 func (s *Service) DetachStorage(r *request.DetachStorageRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -459,7 +459,7 @@ func (s *Service) DetachStorage(r *request.DetachStorageRequest) (*upcloud.Serve
 
 // DeleteStorage deletes the specified storage device
 func (s *Service) DeleteStorage(r *request.DeleteStorageRequest) error {
-	err := s.client.PerformDeleteRequest(s.client.CreateRequestUrl(r.RequestURL()))
+	err := s.client.PerformDeleteRequest(s.client.CreateRequestURL(r.RequestURL()))
 
 	if err != nil {
 		return parseServiceError(err)
@@ -472,7 +472,7 @@ func (s *Service) DeleteStorage(r *request.DeleteStorageRequest) error {
 func (s *Service) CloneStorage(r *request.CloneStorageRequest) (*upcloud.StorageDetails, error) {
 	storageDetails := upcloud.StorageDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -487,7 +487,7 @@ func (s *Service) CloneStorage(r *request.CloneStorageRequest) (*upcloud.Storage
 func (s *Service) TemplatizeStorage(r *request.TemplatizeStorageRequest) (*upcloud.StorageDetails, error) {
 	storageDetails := upcloud.StorageDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -531,7 +531,7 @@ func (s *Service) WaitForStorageState(r *request.WaitForStorageStateRequest) (*u
 func (s *Service) LoadCDROM(r *request.LoadCDROMRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -546,7 +546,7 @@ func (s *Service) LoadCDROM(r *request.LoadCDROMRequest) (*upcloud.ServerDetails
 func (s *Service) EjectCDROM(r *request.EjectCDROMRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -561,7 +561,7 @@ func (s *Service) EjectCDROM(r *request.EjectCDROMRequest) (*upcloud.ServerDetai
 func (s *Service) CreateBackup(r *request.CreateBackupRequest) (*upcloud.StorageDetails, error) {
 	storageDetails := upcloud.StorageDetails{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -575,7 +575,7 @@ func (s *Service) CreateBackup(r *request.CreateBackupRequest) (*upcloud.Storage
 // RestoreBackup creates a backup of the specified storage
 func (s *Service) RestoreBackup(r *request.RestoreBackupRequest) error {
 	requestBody, _ := xml.Marshal(r)
-	_, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	_, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return parseServiceError(err)
@@ -616,7 +616,7 @@ func (s *Service) GetIPAddressDetails(r *request.GetIPAddressDetailsRequest) (*u
 func (s *Service) AssignIPAddress(r *request.AssignIPAddressRequest) (*upcloud.IPAddress, error) {
 	ipAddress := upcloud.IPAddress{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -631,7 +631,7 @@ func (s *Service) AssignIPAddress(r *request.AssignIPAddressRequest) (*upcloud.I
 func (s *Service) ModifyIPAddress(r *request.ModifyIPAddressRequest) (*upcloud.IPAddress, error) {
 	ipAddress := upcloud.IPAddress{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPutRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPutRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -644,7 +644,7 @@ func (s *Service) ModifyIPAddress(r *request.ModifyIPAddressRequest) (*upcloud.I
 
 // ReleaseIPAddress releases the specified IP address from the server it is attached to
 func (s *Service) ReleaseIPAddress(r *request.ReleaseIPAddressRequest) error {
-	err := s.client.PerformDeleteRequest(s.client.CreateRequestUrl(r.RequestURL()))
+	err := s.client.PerformDeleteRequest(s.client.CreateRequestURL(r.RequestURL()))
 
 	if err != nil {
 		return parseServiceError(err)
@@ -685,7 +685,7 @@ func (s *Service) GetFirewallRuleDetails(r *request.GetFirewallRuleDetailsReques
 func (s *Service) CreateFirewallRule(r *request.CreateFirewallRuleRequest) (*upcloud.FirewallRule, error) {
 	firewallRule := upcloud.FirewallRule{}
 	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	response, err := s.client.PerformPostRequest(s.client.CreateRequestURL(r.RequestURL()), requestBody)
 
 	if err != nil {
 		return nil, parseServiceError(err)
@@ -698,7 +698,7 @@ func (s *Service) CreateFirewallRule(r *request.CreateFirewallRuleRequest) (*upc
 
 // DeleteFirewallRule deletes the specified firewall rule
 func (s *Service) DeleteFirewallRule(r *request.DeleteFirewallRuleRequest) error {
-	err := s.client.PerformDeleteRequest(s.client.CreateRequestUrl(r.RequestURL()))
+	err := s.client.PerformDeleteRequest(s.client.CreateRequestURL(r.RequestURL()))
 
 	if err != nil {
 		return parseServiceError(err)
@@ -723,7 +723,7 @@ func (s *Service) GetTags() (*upcloud.Tags, error) {
 
 // Wrapper that performs a GET request to the specified location and returns the response or a service error
 func (s *Service) basicGetRequest(location string) ([]byte, error) {
-	requestUrl := s.client.CreateRequestUrl(location)
+	requestUrl := s.client.CreateRequestURL(location)
 	response, err := s.client.PerformGetRequest(requestUrl)
 
 	if err != nil {
@@ -735,7 +735,7 @@ func (s *Service) basicGetRequest(location string) ([]byte, error) {
 
 // Wrapper that performs a GET request to the specified location and returns the response or a service error
 func (s *Service) basicJSONGetRequest(location string) ([]byte, error) {
-	requestURL := s.client.CreateRequestUrl(location)
+	requestURL := s.client.CreateRequestURL(location)
 	response, err := s.client.PerformJSONGetRequest(requestURL)
 
 	if err != nil {

--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"time"
 
@@ -156,6 +157,16 @@ func (s *Service) CreateServer(r *request.CreateServerRequest) (*upcloud.ServerD
 	}
 
 	return &serverDetails, nil
+}
+
+func (s *Service) CreateServerOption1(json string) (string, error) {
+	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestUrl("/server"), []byte(json))
+
+	if err != nil {
+		return "", errors.New(string(err.(*client.Error).ResponseBody))
+	}
+
+	return string(response), nil
 }
 
 // WaitForServerState blocks execution until the specified server has entered the specified state. If the state changes

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -539,7 +539,7 @@ func TestCreateBackup(t *testing.T) {
 		t,
 		backupStorageDetails.Origin,
 		storageDetails.UUID,
-		"The origin UUID %s of backup storage UUID %s does not match the actual origina UUID %s",
+		"The origin UUID %s of backup storage UUID %s does not match the actual origin UUID %s",
 		backupStorageDetails.Origin,
 		backupDetails.UUID,
 		storageDetails.UUID,
@@ -547,8 +547,8 @@ func TestCreateBackup(t *testing.T) {
 
 	assert.Greaterf(
 		t,
-		backupStorageDetails.Created,
-		timeBeforeBackup,
+		backupStorageDetails.Created.Unix(),
+		timeBeforeBackup.Unix(),
 		"The creation timestamp of backup storage UUID %s is too early: %v (should be after %v)",
 		backupDetails.UUID,
 		backupStorageDetails.Created,
@@ -557,8 +557,8 @@ func TestCreateBackup(t *testing.T) {
 
 	assert.Lessf(
 		t,
-		backupStorageDetails.Created,
-		timeAfterBackup,
+		backupStorageDetails.Created.Unix(),
+		timeAfterBackup.Unix(),
 		"The creation timestamp of backup storage UUID %s is too late: %v (should be before %v)",
 		backupDetails.UUID,
 		backupStorageDetails.Created,

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -547,8 +547,8 @@ func TestCreateBackup(t *testing.T) {
 
 	assert.Greaterf(
 		t,
-		backupStorageDetails.Created.Unix(),
-		timeBeforeBackup.Unix(),
+		backupStorageDetails.Created.UnixNano(),
+		timeBeforeBackup.UnixNano(),
 		"The creation timestamp of backup storage UUID %s is too early: %v (should be after %v)",
 		backupDetails.UUID,
 		backupStorageDetails.Created,
@@ -557,8 +557,8 @@ func TestCreateBackup(t *testing.T) {
 
 	assert.Lessf(
 		t,
-		backupStorageDetails.Created.Unix(),
-		timeAfterBackup.Unix(),
+		backupStorageDetails.Created.UnixNano(),
+		timeAfterBackup.UnixNano(),
 		"The creation timestamp of backup storage UUID %s is too late: %v (should be before %v)",
 		backupDetails.UUID,
 		backupStorageDetails.Created,

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -545,7 +545,7 @@ func TestCreateBackup(t *testing.T) {
 		storageDetails.UUID,
 	)
 
-	assert.Greaterf(
+	assert.GreaterOrEqualf(
 		t,
 		backupStorageDetails.Created.UnixNano(),
 		timeBeforeBackup.UnixNano(),
@@ -555,7 +555,7 @@ func TestCreateBackup(t *testing.T) {
 		timeBeforeBackup,
 	)
 
-	assert.Lessf(
+	assert.LessOrEqualf(
 		t,
 		backupStorageDetails.Created.UnixNano(),
 		timeAfterBackup.UnixNano(),

--- a/upcloud/service/service_test.go
+++ b/upcloud/service/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +34,7 @@ func TestMain(m *testing.M) {
 func getService() *Service {
 	user, password := getCredentials()
 
-	c := client.New(user, password)
+	c := client.NewWithHTTPClient(user, password, cleanhttp.DefaultClient())
 	c.SetTimeout(time.Second * 300)
 
 	return New(c)

--- a/upcloud/storage.go
+++ b/upcloud/storage.go
@@ -95,14 +95,14 @@ type ServerStorageDevice struct {
 
 // CreateServerStorageDevice represents a storage device for a CreateServerRequest
 type CreateServerStorageDevice struct {
-	XMLName xml.Name `xml:"storage_device"`
+	XMLName xml.Name `xml:"storage_device" json:"-"`
 
-	Action  string `xml:"action"`
-	Address string `xml:"address,omitempty"`
-	Storage string `xml:"storage"`
-	Title   string `xml:"title,omitempty"`
+	Action  string `xml:"action" json:"action"`
+	Address string `xml:"address,omitempty" json:"address,omitempty"`
+	Storage string `xml:"storage" json:"storage"`
+	Title   string `xml:"title,omitempty" json:"title,omitempty"`
 	// Storage size in gigabytes
-	Size int    `xml:"size"`
-	Tier string `xml:"tier,omitempty"`
-	Type string `xml:"type,omitempty"`
+	Size int    `xml:"size" json:"size"`
+	Tier string `xml:"tier,omitempty" json:"tier,omitempty"`
+	Type string `xml:"type,omitempty" json:"type,omitempty"`
 }


### PR DESCRIPTION
Changes:

* Convert `DeleteServerAndStorage` and `GetServers` to use JSON API.
* Add custom `UnmarshalJSON` functions to workaround deeply embedded fields.
* Add custom `UnmarshalJSON` to `Error` struct to unmarshal errors.
* Update tests.
* Add example use of Go API.