### PR TITLE
Convert GetServers, CreateServer and DeleteServerAndStorages to use JSON API

### DIFF
--- a/examples/upcloud-cli/main.go
+++ b/examples/upcloud-cli/main.go
@@ -85,6 +85,14 @@ func deleteServers(s *service.Service) error {
 					fmt.Fprintf(os.Stderr, "Unable to stop server: %#v\n", err)
 					return err
 				}
+				_, err = s.WaitForServerState(&request.WaitForServerStateRequest{
+					UUID:         server.UUID,
+					DesiredState: upcloud.ServerStateStopped,
+				})
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to wait for server to reach desired state: %#v", err)
+					return err
+				}
 			}
 			fmt.Printf("Deleting %s (%s)\n", server.Title, server.UUID)
 			err := s.DeleteServerAndStorages(&request.DeleteServerAndStoragesRequest{

--- a/examples/upcloud-cli/main.go
+++ b/examples/upcloud-cli/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"git.sr.ht/~yoink00/goflenfig"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
+)
+
+var username string
+var password string
+
+func init() {
+	goflenfig.Prefix("UPCLOUD_")
+	goflenfig.StringVar(&username, "username", "", "UpCloud user name")
+	goflenfig.StringVar(&password, "password", "", "UpCloud password")
+}
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	goflenfig.Parse()
+
+	command := flag.Arg(0)
+
+	if len(username) == 0 {
+		fmt.Fprintln(os.Stderr, "Username must be specified")
+		return 1
+	}
+
+	if len(password) == 0 {
+		fmt.Fprintln(os.Stderr, "Password must be specified")
+		return 2
+	}
+
+	fmt.Println("Creating new client")
+	c := client.New(username, password)
+	s := service.New(c)
+
+	switch command {
+	case "deleteservers":
+		if err := deleteServers(s); err != nil {
+			return 1
+		}
+	case "deletestorage":
+		if err := deleteStorage(s); err != nil {
+			return 2
+		}
+	default:
+		fmt.Fprintln(os.Stderr, "Unknown command: ", command)
+		return 99
+	}
+
+	return 0
+}
+
+func deleteServers(s *service.Service) error {
+	fmt.Println("Getting servers")
+	servers, err := s.GetServers()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get servers: %#v\n", err)
+		return err
+	}
+
+	fmt.Printf("Retrieved %d servers\n", len(servers.Servers))
+
+	if len(servers.Servers) > 0 {
+		fmt.Println("Deleting all servers")
+		for _, server := range servers.Servers {
+			if server.State != upcloud.ServerStateStopped {
+				fmt.Printf("Server %s (%s) is not stopped. Stopping\n", server.Title, server.UUID)
+				_, err := s.StopServer(&request.StopServerRequest{
+					UUID:     server.UUID,
+					StopType: request.ServerStopTypeHard,
+				})
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Unable to stop server: %#v\n", err)
+					return err
+				}
+			}
+			fmt.Printf("Deleting %s (%s)\n", server.Title, server.UUID)
+			err := s.DeleteServerAndStorages(&request.DeleteServerAndStoragesRequest{
+				UUID: server.UUID,
+			})
+
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to delete server: %#v\n", err)
+				return err
+			}
+			fmt.Printf("Successfully deleted %s (%s)\n", server.Title, server.UUID)
+		}
+	}
+
+	return nil
+}
+
+func deleteStorage(s *service.Service) error {
+	fmt.Println("Getting storage")
+	storages, err := s.GetStorages(&request.GetStoragesRequest{
+		Access: upcloud.StorageAccessPrivate,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get storages: %#v\n", err)
+		return err
+	}
+
+	fmt.Printf("Retrieved %d storages\n", len(storages.Storages))
+
+	if len(storages.Storages) > 0 {
+		fmt.Println("Deleting all storages")
+		for _, storage := range storages.Storages {
+			err := errors.New("Dummy")
+			for i := 0; err != nil && i < 5; i++ {
+				fmt.Printf("%d: Deleting %s (%s)\n", i, storage.Title, storage.UUID)
+				err = s.DeleteStorage(&request.DeleteStorageRequest{
+					UUID: storage.UUID,
+				})
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to delete storage: %#v (%s)\n", err, err.Error())
+				return err
+			}
+
+			fmt.Printf("Successfully deleted %s (%s)\n", storage.Title, storage.UUID)
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	git.sr.ht/~yoink00/goflenfig v0.1.0
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	git.sr.ht/~yoink00/goflenfig v0.1.0
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/UpCloudLtd/upcloud-go-api
 go 1.14
 
 require (
+	git.sr.ht/~yoink00/goflenfig v0.1.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+git.sr.ht/~yoink00/goflenfig v0.1.0 h1:8RqL7olbs64EHus97F+S1wuPKFco9Av2FmY3Sk6bPoQ=
+git.sr.ht/~yoink00/goflenfig v0.1.0/go.mod h1:+b5SR2TmdQHQ2WqgotlpJEN0xjijoDz6V3pzyfyc6v4=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -91,13 +91,30 @@ func (c *Client) PerformPostRequest(url string, requestBody []byte) ([]byte, err
 		bodyReader = bytes.NewBuffer(requestBody)
 	}
 
-	request, err := http.NewRequest("POST", url, bodyReader)
+	request, err := http.NewRequest(http.MethodPost, url, bodyReader)
 
 	if err != nil {
 		return nil, err
 	}
 
 	return c.performRequest(request)
+}
+
+// PerformPostRequest performs a POST request to the specified URL and returns the response body and eventual errors
+func (c *Client) PerformJSONPostRequest(url string, requestBody []byte) ([]byte, error) {
+	var bodyReader io.Reader
+
+	if requestBody != nil {
+		bodyReader = bytes.NewBuffer(requestBody)
+	}
+
+	request, err := http.NewRequest(http.MethodPost, url, bodyReader)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c.performJSONRequest(request)
 }
 
 // PerformPutRequest performs a PUT request to the specified URL and returns the response body and eventual errors

--- a/upcloud/client/client.go
+++ b/upcloud/client/client.go
@@ -63,13 +63,24 @@ func (c *Client) CreateRequestUrl(location string) string {
 
 // PerformGetRequest performs a GET request to the specified URL and returns the response body and eventual errors
 func (c *Client) PerformGetRequest(url string) ([]byte, error) {
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 
 	if err != nil {
 		return nil, err
 	}
 
 	return c.performRequest(request)
+}
+
+// PerformJSONGetRequest performs a GET request to the specified URL and returns the response body and eventual errors
+func (c *Client) PerformJSONGetRequest(url string) ([]byte, error) {
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c.performJSONRequest(request)
 }
 
 // PerformPostRequest performs a POST request to the specified URL and returns the response body and eventual errors
@@ -108,13 +119,25 @@ func (c *Client) PerformPutRequest(url string, requestBody []byte) ([]byte, erro
 
 // PerformDeleteRequest performs a DELETE request to the specified URL and returns the response body and eventual errors
 func (c *Client) PerformDeleteRequest(url string) error {
-	request, err := http.NewRequest("DELETE", url, nil)
+	request, err := http.NewRequest(http.MethodDelete, url, nil)
 
 	if err != nil {
 		return err
 	}
 
 	_, err = c.performRequest(request)
+	return err
+}
+
+// PerformJSONDeleteRequest performs a DELETE request to the specified URL and returns the response body and eventual errors
+func (c *Client) PerformJSONDeleteRequest(url string) error {
+	request, err := http.NewRequest(http.MethodDelete, url, nil)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.performJSONRequest(request)
 	return err
 }
 
@@ -127,9 +150,30 @@ func (c *Client) addRequestHeaders(request *http.Request) *http.Request {
 	return request
 }
 
+// Adds common headers to the specified request
+func (c *Client) addJSONRequestHeaders(request *http.Request) *http.Request {
+	request.SetBasicAuth(c.userName, c.password)
+	request.Header.Add("Accept", "application/json")
+	request.Header.Add("Content-Type", "application/json")
+
+	return request
+}
+
 // Performs the specified HTTP request and returns the response through handleResponse()
 func (c *Client) performRequest(request *http.Request) ([]byte, error) {
 	c.addRequestHeaders(request)
+	response, err := c.httpClient.Do(request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return handleResponse(response)
+}
+
+// Performs the specified HTTP request and returns the response through handleResponse()
+func (c *Client) performJSONRequest(request *http.Request) ([]byte, error) {
+	c.addJSONRequestHeaders(request)
 	response, err := c.httpClient.Do(request)
 
 	if err != nil {

--- a/upcloud/error.go
+++ b/upcloud/error.go
@@ -12,14 +12,16 @@ type Error struct {
 }
 
 func (e *Error) UnmarshalJSON(b []byte) error {
-	var v map[string]map[string]string
+	type localError Error
+	v := struct {
+		Error localError `json:"error"`
+	}{}
 	err := json.Unmarshal(b, &v)
 	if err != nil {
 		return err
 	}
 
-	e.ErrorCode = v["error"]["error_code"]
-	e.ErrorMessage = v["error"]["error_message"]
+	(*e) = Error(v.Error)
 
 	return nil
 }

--- a/upcloud/error.go
+++ b/upcloud/error.go
@@ -12,8 +12,6 @@ type Error struct {
 }
 
 func (e *Error) UnmarshalJSON(b []byte) error {
-	fmt.Println("Unmarshalling: ", string(b))
-
 	var v map[string]map[string]string
 	err := json.Unmarshal(b, &v)
 	if err != nil {

--- a/upcloud/error.go
+++ b/upcloud/error.go
@@ -1,11 +1,29 @@
 package upcloud
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Error represents an error
 type Error struct {
-	ErrorCode    string `xml:"error_code"`
-	ErrorMessage string `xml:"error_message"`
+	ErrorCode    string `xml:"error_code" json:"error_code"`
+	ErrorMessage string `xml:"error_message" json:"error_message"`
+}
+
+func (e *Error) UnmarshalJSON(b []byte) error {
+	fmt.Println("Unmarshalling: ", string(b))
+
+	var v map[string]map[string]string
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	e.ErrorCode = v["error"]["error_code"]
+	e.ErrorMessage = v["error"]["error_message"]
+
+	return nil
 }
 
 // Error implements the Error interface

--- a/upcloud/error_test.go
+++ b/upcloud/error_test.go
@@ -1,0 +1,26 @@
+package upcloud
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUnmarshalFirewallRules tests the FirewallRules and FirewallRule are unmarshaled correctly
+func TestError(t *testing.T) {
+	originalJSON := `
+        {
+            "error": {
+              "error_message": "The server 00af0f73-7082-4283-b925-811d1585774b does not exist.",
+              "error_code": "SERVER_NOT_FOUND"
+            }
+        }
+    `
+
+	e := Error{}
+	err := json.Unmarshal([]byte(originalJSON), &e)
+	assert.NoError(t, err)
+	assert.Equal(t, "The server 00af0f73-7082-4283-b925-811d1585774b does not exist.", e.ErrorMessage)
+	assert.Equal(t, "SERVER_NOT_FOUND", e.ErrorCode)
+}

--- a/upcloud/ip_address.go
+++ b/upcloud/ip_address.go
@@ -16,11 +16,11 @@ type IPAddresses struct {
 
 // IPAddress represents an IP address
 type IPAddress struct {
-	Access  string `xml:"access"`
-	Address string `xml:"address"`
-	Family  string `xml:"family"`
+	Access  string `xml:"access" json:"access"`
+	Address string `xml:"address" json:"address"`
+	Family  string `xml:"family" json:"family"`
 	// TODO: Convert to boolean
-	PartOfPlan string `xml:"part_of_plan"`
-	PTRRecord  string `xml:"ptr_record"`
-	ServerUUID string `xml:"server"`
+	PartOfPlan string `xml:"part_of_plan" json:"part_of_plan"`
+	PTRRecord  string `xml:"ptr_record" json:"ptr_record"`
+	ServerUUID string `xml:"server" json:"server"`
 }

--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -96,11 +96,37 @@ func (r *CreateServerRequest) RequestURL() string {
 	return "/server"
 }
 
+type SSHKeySlice []string
+
+func (s *SSHKeySlice) UnmarshalJSON(b []byte) error {
+	v := struct {
+		SSHKey []string `json:"ssh_key"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*s) = v.SSHKey
+
+	return nil
+}
+
+func (s SSHKeySlice) MarshalJSON() ([]byte, error) {
+	v := struct {
+		SSHKey []string `json:"ssh_key"`
+	}{}
+
+	v.SSHKey = s
+
+	return json.Marshal(v)
+}
+
 // LoginUser represents the login_user block when creating a new server
 type LoginUser struct {
-	CreatePassword string   `xml:"create_password,omitempty" json:"create_password,omitempty"`
-	Username       string   `xml:"username,omitempty" json:"username,omitempty"`
-	SSHKeys        []string `xml:"ssh_keys>ssh_key,omitempty" json:"ssh_keys"`
+	CreatePassword string      `xml:"create_password,omitempty" json:"create_password,omitempty"`
+	Username       string      `xml:"username,omitempty" json:"username,omitempty"`
+	SSHKeys        SSHKeySlice `xml:"ssh_keys>ssh_key,omitempty" json:"ssh_keys"`
 }
 
 // CreateServerIPAddress represents an IP address for a CreateServerRequest

--- a/upcloud/request/server.go
+++ b/upcloud/request/server.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"strings"
@@ -32,30 +33,62 @@ func (r *GetServerDetailsRequest) RequestURL() string {
 	return fmt.Sprintf("/server/%s", r.UUID)
 }
 
+type CreateServerIPAddressSlice []CreateServerIPAddress
+
+func (s CreateServerIPAddressSlice) MarshalJSON() ([]byte, error) {
+	v := struct {
+		IPAddress []CreateServerIPAddress `json:"ip_address"`
+	}{}
+	v.IPAddress = s
+
+	return json.Marshal(v)
+}
+
+type CreateServerStorageDeviceSlice []upcloud.CreateServerStorageDevice
+
+func (s CreateServerStorageDeviceSlice) MarshalJSON() ([]byte, error) {
+	v := struct {
+		StorageDevice []upcloud.CreateServerStorageDevice `json:"storage_device"`
+	}{}
+	v.StorageDevice = s
+
+	return json.Marshal(v)
+}
+
 // CreateServerRequest represents a request for creating a new server
 type CreateServerRequest struct {
-	XMLName xml.Name `xml:"server"`
+	XMLName xml.Name `xml:"server" json:"-"`
 
-	AvoidHost  string `xml:"avoid_host,omitempty"`
-	BootOrder  string `xml:"boot_order,omitempty"`
-	CoreNumber int    `xml:"core_number,omitempty"`
+	AvoidHost  string `xml:"avoid_host,omitempty" json:"avoid_host,omitempty"`
+	BootOrder  string `xml:"boot_order,omitempty" json:"boot_order,omitempty"`
+	CoreNumber int    `xml:"core_number,omitempty" json:"core_number,omitempty"`
 	// TODO: Convert to boolean
-	Firewall         string                              `xml:"firewall,omitempty"`
-	Hostname         string                              `xml:"hostname"`
-	IPAddresses      []CreateServerIPAddress             `xml:"ip_addresses>ip_address"`
-	LoginUser        *LoginUser                          `xml:"login_user,omitempty"`
-	MemoryAmount     int                                 `xml:"memory_amount,omitempty"`
-	PasswordDelivery string                              `xml:"password_delivery,omitempty"`
-	Plan             string                              `xml:"plan,omitempty"`
-	StorageDevices   []upcloud.CreateServerStorageDevice `xml:"storage_devices>storage_device"`
-	TimeZone         string                              `xml:"timezone,omitempty"`
-	Title            string                              `xml:"title"`
-	UserData         string                              `xml:"user_data,omitempty"`
-	VideoModel       string                              `xml:"video_model,omitempty"`
+	Firewall         string                         `xml:"firewall,omitempty" json:"firewall,omitempty"`
+	Hostname         string                         `xml:"hostname" json:"hostname"`
+	IPAddresses      CreateServerIPAddressSlice     `xml:"ip_addresses>ip_address" json:"ip_addresses"`
+	LoginUser        *LoginUser                     `xml:"login_user,omitempty" json:"login_user,omitempty"`
+	MemoryAmount     int                            `xml:"memory_amount,omitempty" json:"memory_amount,omitempty"`
+	PasswordDelivery string                         `xml:"password_delivery,omitempty" json:"password_delivery,omitempty"`
+	Plan             string                         `xml:"plan,omitempty" json:"plan,omitempty"`
+	StorageDevices   CreateServerStorageDeviceSlice `xml:"storage_devices>storage_device" json:"storage_devices"`
+	TimeZone         string                         `xml:"timezone,omitempty" json:"timezone,omitempty"`
+	Title            string                         `xml:"title" json:"title"`
+	UserData         string                         `xml:"user_data,omitempty" json:"user_data,omitempty"`
+	VideoModel       string                         `xml:"video_model,omitempty" json:"video_model,omitempty"`
 	// TODO: Convert to boolean
-	VNC         string `xml:"vnc,omitempty"`
-	VNCPassword string `xml:"vnc_password,omitempty"`
-	Zone        string `xml:"zone"`
+	VNC         string `xml:"vnc,omitempty" json:"vnc,omitempty"`
+	VNCPassword string `xml:"vnc_password,omitempty" json:"vnc_password,omitempty"`
+	Zone        string `xml:"zone" json:"zone"`
+}
+
+func (r CreateServerRequest) MarshalJSON() ([]byte, error) {
+	type localCreateServerRequest CreateServerRequest
+	v := struct {
+		Server localCreateServerRequest `json:"server"`
+	}{}
+	v.Server = localCreateServerRequest(r)
+
+	return json.Marshal(&v)
 }
 
 // RequestURL implements the Request interface
@@ -65,15 +98,15 @@ func (r *CreateServerRequest) RequestURL() string {
 
 // LoginUser represents the login_user block when creating a new server
 type LoginUser struct {
-	CreatePassword string   `xml:"create_password,omitempty"`
-	Username       string   `xml:"username,omitempty"`
-	SSHKeys        []string `xml:"ssh_keys>ssh_key,omitempty"`
+	CreatePassword string   `xml:"create_password,omitempty" json:"create_password,omitempty"`
+	Username       string   `xml:"username,omitempty" json:"username,omitempty"`
+	SSHKeys        []string `xml:"ssh_keys>ssh_key,omitempty" json:"ssh_keys"`
 }
 
 // CreateServerIPAddress represents an IP address for a CreateServerRequest
 type CreateServerIPAddress struct {
-	Access string `xml:"access"`
-	Family string `xml:"family"`
+	Access string `xml:"access" json:"access"`
+	Family string `xml:"family" json:"family"`
 }
 
 // WaitForServerStateRequest represents a request to wait for a server to enter or exit a specific state

--- a/upcloud/request/server_test.go
+++ b/upcloud/request/server_test.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"testing"
 	"time"
@@ -57,10 +58,53 @@ func TestCreateServerRequest(t *testing.T) {
 		},
 	}
 
-	expectedXML := "<server><hostname>debian.example.com</hostname><ip_addresses><ip_address><access>private</access><family>IPv4</family></ip_address><ip_address><access>public</access><family>IPv4</family></ip_address><ip_address><access>public</access><family>IPv6</family></ip_address></ip_addresses><login_user><create_password>no</create_password><ssh_keys><ssh_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCWf2MmpHweXCNUcW91PWZR5UqOkydBr1Gi1xDI16IW4JndMYkH9OF0sWvPz03kfY6NbcHY0bed1Q8BpAC//WfLltuvjrzk33IoFJZ2Ai+4fVdkevkf7pBeSvzdXSyKAT+suHrp/2Qu5hewIUdDCp+znkwyypIJ/C2hDphwbLR3QquOfn6KyKMPZC4my8dFvLxESI0UqeripaBHUGcvNG2LL563hXmWzUu/cyqCpg5IBzpj/ketg8m1KBO7U0dimIAczuxfHk3kp9bwOFquWA2vSFNuVkr8oavk36pHkU88qojYNEy/zUTINE0w6CE/EbDkQVDZEGgDtAkq4jL+4MPV negge@palinski</ssh_key><ssh_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJfx4OmD8D6mnPA0BPk2DVlbggEkMvB2cecSttauZuaYX7Vju6PvG+kXrUbTvO09oLQMoNYAk3RinqQLXo9eF7bzZIsgB4ZmKGau84kOpYjguhimkKtZiVTKF53G2pbnpiZUN9wfy3xK2mt/MkacjZ1Tp7lAgRGTfWDoTfQa88kzOJGNPWXd12HIvFtd/1KoS9vm5O0nDLV+5zSBLxEYNDmBlIGu1Y3XXle5ygL1BhfGvqOQnv/TdRZcrOgVGWHADvwEid91/+IycLNMc37uP7TdS6vOihFBMytfmFXAqt4+3AzYNmyc+R392RorFzobZ1UuEFm3gUod2Wvj8pY8d/ negge@palinski</ssh_key></ssh_keys></login_user><password_delivery>none</password_delivery><storage_devices><storage_device><action>clone</action><storage>01000000-0000-4000-8000-000030060200</storage><title>disk1</title><size>30</size><tier>maxiops</tier></storage_device></storage_devices><title>Integration test server #1</title><zone>fi-hel2</zone></server>"
-	actualXML, err := xml.Marshal(&request)
+	expectedJSON := `
+	{
+      "server": {
+        "hostname": "debian.example.com",
+        "ip_addresses": {
+          "ip_address": [
+            {
+              "access": "private",
+              "family": "IPv4"
+            },
+            {
+              "access": "public",
+              "family": "IPv4"
+            },
+            {
+              "access": "public",
+              "family": "IPv6"
+            }
+          ]
+        },
+        "login_user": {
+          "create_password": "no",
+          "ssh_keys": [
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCWf2MmpHweXCNUcW91PWZR5UqOkydBr1Gi1xDI16IW4JndMYkH9OF0sWvPz03kfY6NbcHY0bed1Q8BpAC//WfLltuvjrzk33IoFJZ2Ai+4fVdkevkf7pBeSvzdXSyKAT+suHrp/2Qu5hewIUdDCp+znkwyypIJ/C2hDphwbLR3QquOfn6KyKMPZC4my8dFvLxESI0UqeripaBHUGcvNG2LL563hXmWzUu/cyqCpg5IBzpj/ketg8m1KBO7U0dimIAczuxfHk3kp9bwOFquWA2vSFNuVkr8oavk36pHkU88qojYNEy/zUTINE0w6CE/EbDkQVDZEGgDtAkq4jL+4MPV negge@palinski",
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJfx4OmD8D6mnPA0BPk2DVlbggEkMvB2cecSttauZuaYX7Vju6PvG+kXrUbTvO09oLQMoNYAk3RinqQLXo9eF7bzZIsgB4ZmKGau84kOpYjguhimkKtZiVTKF53G2pbnpiZUN9wfy3xK2mt/MkacjZ1Tp7lAgRGTfWDoTfQa88kzOJGNPWXd12HIvFtd/1KoS9vm5O0nDLV+5zSBLxEYNDmBlIGu1Y3XXle5ygL1BhfGvqOQnv/TdRZcrOgVGWHADvwEid91/+IycLNMc37uP7TdS6vOihFBMytfmFXAqt4+3AzYNmyc+R392RorFzobZ1UuEFm3gUod2Wvj8pY8d/ negge@palinski"
+          ]
+        },
+        "password_delivery": "none",
+        "storage_devices": {
+          "storage_device": [
+            {
+              "action": "clone",
+              "storage": "01000000-0000-4000-8000-000030060200",
+              "title": "disk1",
+              "size": 30,
+              "tier": "maxiops"
+            }
+          ]
+        },
+        "title": "Integration test server #1",
+        "zone": "fi-hel2"
+      }
+    }
+	`
+	actualJSON, err := json.Marshal(&request)
 	assert.Nil(t, err)
-	assert.Equal(t, expectedXML, string(actualXML))
+	assert.JSONEq(t, expectedJSON, string(actualJSON))
 	assert.Equal(t, "/server", request.RequestURL())
 }
 

--- a/upcloud/request/server_test.go
+++ b/upcloud/request/server_test.go
@@ -80,10 +80,12 @@ func TestCreateServerRequest(t *testing.T) {
         },
         "login_user": {
           "create_password": "no",
-          "ssh_keys": [
-            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCWf2MmpHweXCNUcW91PWZR5UqOkydBr1Gi1xDI16IW4JndMYkH9OF0sWvPz03kfY6NbcHY0bed1Q8BpAC//WfLltuvjrzk33IoFJZ2Ai+4fVdkevkf7pBeSvzdXSyKAT+suHrp/2Qu5hewIUdDCp+znkwyypIJ/C2hDphwbLR3QquOfn6KyKMPZC4my8dFvLxESI0UqeripaBHUGcvNG2LL563hXmWzUu/cyqCpg5IBzpj/ketg8m1KBO7U0dimIAczuxfHk3kp9bwOFquWA2vSFNuVkr8oavk36pHkU88qojYNEy/zUTINE0w6CE/EbDkQVDZEGgDtAkq4jL+4MPV negge@palinski",
-            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJfx4OmD8D6mnPA0BPk2DVlbggEkMvB2cecSttauZuaYX7Vju6PvG+kXrUbTvO09oLQMoNYAk3RinqQLXo9eF7bzZIsgB4ZmKGau84kOpYjguhimkKtZiVTKF53G2pbnpiZUN9wfy3xK2mt/MkacjZ1Tp7lAgRGTfWDoTfQa88kzOJGNPWXd12HIvFtd/1KoS9vm5O0nDLV+5zSBLxEYNDmBlIGu1Y3XXle5ygL1BhfGvqOQnv/TdRZcrOgVGWHADvwEid91/+IycLNMc37uP7TdS6vOihFBMytfmFXAqt4+3AzYNmyc+R392RorFzobZ1UuEFm3gUod2Wvj8pY8d/ negge@palinski"
-          ]
+          "ssh_keys": {
+			  "ssh_key": [
+                "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCWf2MmpHweXCNUcW91PWZR5UqOkydBr1Gi1xDI16IW4JndMYkH9OF0sWvPz03kfY6NbcHY0bed1Q8BpAC//WfLltuvjrzk33IoFJZ2Ai+4fVdkevkf7pBeSvzdXSyKAT+suHrp/2Qu5hewIUdDCp+znkwyypIJ/C2hDphwbLR3QquOfn6KyKMPZC4my8dFvLxESI0UqeripaBHUGcvNG2LL563hXmWzUu/cyqCpg5IBzpj/ketg8m1KBO7U0dimIAczuxfHk3kp9bwOFquWA2vSFNuVkr8oavk36pHkU88qojYNEy/zUTINE0w6CE/EbDkQVDZEGgDtAkq4jL+4MPV negge@palinski",
+				"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJfx4OmD8D6mnPA0BPk2DVlbggEkMvB2cecSttauZuaYX7Vju6PvG+kXrUbTvO09oLQMoNYAk3RinqQLXo9eF7bzZIsgB4ZmKGau84kOpYjguhimkKtZiVTKF53G2pbnpiZUN9wfy3xK2mt/MkacjZ1Tp7lAgRGTfWDoTfQa88kzOJGNPWXd12HIvFtd/1KoS9vm5O0nDLV+5zSBLxEYNDmBlIGu1Y3XXle5ygL1BhfGvqOQnv/TdRZcrOgVGWHADvwEid91/+IycLNMc37uP7TdS6vOihFBMytfmFXAqt4+3AzYNmyc+R392RorFzobZ1UuEFm3gUod2Wvj8pY8d/ negge@palinski"
+			  ]
+		  }
         },
         "password_delivery": "none",
         "storage_devices": {

--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -75,7 +75,7 @@ type Server struct {
 	License      float64  `xml:"license" json:"license"`
 	MemoryAmount int      `xml:"memory_amount" json:"memory_amount,string"`
 	Plan         string   `xml:"plan" json:"plan"`
-	Progress     int      `xml:"progress" json:"progress"`
+	Progress     int      `xml:"progress" json:"progress,string"`
 	State        string   `xml:"state" json:"state"`
 	Tags         TagSlice `xml:"tags>tag" json:"tags"`
 	Title        string   `xml:"title" json:"title"`
@@ -83,23 +83,71 @@ type Server struct {
 	Zone         string   `xml:"zone" json:"zone"`
 }
 
+type IPAddressSlice []IPAddress
+
+func (i *IPAddressSlice) UnmarshalJSON(b []byte) error {
+	v := struct {
+		IPAddresses []IPAddress `json:"ip_address"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*i) = v.IPAddresses
+
+	return nil
+}
+
+type ServerStorageDeviceSlice []ServerStorageDevice
+
+func (s *ServerStorageDeviceSlice) UnmarshalJSON(b []byte) error {
+	v := struct {
+		StorageDevices []ServerStorageDevice `json:"storage_device"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*s) = v.StorageDevices
+
+	return nil
+}
+
 // ServerDetails represents details about a server
 type ServerDetails struct {
 	Server
 
-	BootOrder  string `xml:"boot_order"`
-	CoreNumber int    `xml:"core_number"`
+	BootOrder  string `xml:"boot_order" json:"boot_order"`
+	CoreNumber int    `xml:"core_number" json:"core_number,string"`
 	// TODO: Convert to boolean
-	Firewall       string                `xml:"firewall"`
-	Host           int                   `xml:"host"`
-	IPAddresses    []IPAddress           `xml:"ip_addresses>ip_address"`
-	NICModel       string                `xml:"nic_model"`
-	StorageDevices []ServerStorageDevice `xml:"storage_devices>storage_device"`
-	Timezone       string                `xml:"timezone"`
-	VideoModel     string                `xml:"video_model"`
+	Firewall       string                   `xml:"firewall" json:"firewall"`
+	Host           int                      `xml:"host" json:"host"`
+	IPAddresses    IPAddressSlice           `xml:"ip_addresses>ip_address" json:"ip_addresses"`
+	NICModel       string                   `xml:"nic_model" json:"nic_model"`
+	StorageDevices ServerStorageDeviceSlice `xml:"storage_devices>storage_device" json:"storage_devices"`
+	Timezone       string                   `xml:"timezone" json:"timezone"`
+	VideoModel     string                   `xml:"video_model" json:"video_model"`
 	// TODO: Convert to boolean
-	VNC         string `xml:"vnc"`
-	VNCHost     string `xml:"vnc_host"`
-	VNCPassword string `xml:"vnc_password"`
-	VNCPort     int    `xml:"vnc_port"`
+	VNC         string `xml:"vnc" json:"vnc"`
+	VNCHost     string `xml:"vnc_host" json:"vnc_host"`
+	VNCPassword string `xml:"vnc_password" json:"vnc_password"`
+	VNCPort     int    `xml:"vnc_port" json:"vnc_port"`
+}
+
+func (s *ServerDetails) UnmarshalJSON(b []byte) error {
+	type localServerDetails ServerDetails
+
+	v := struct {
+		ServerDetails localServerDetails `json:"server"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*s) = ServerDetails(v.ServerDetails)
+
+	return nil
 }

--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -1,5 +1,9 @@
 package upcloud
 
+import (
+	"encoding/json"
+)
+
 // Constants
 const (
 	ServerStateStarted     = "started"
@@ -27,22 +31,56 @@ type ServerConfiguration struct {
 
 // Servers represents a /server response
 type Servers struct {
-	Servers []Server `xml:"server"`
+	Servers []Server `xml:"server" json:"servers"`
+}
+
+func (s *Servers) UnmarshalJSON(b []byte) error {
+	type serverWrapper struct {
+		Servers []Server `json:"server"`
+	}
+
+	v := struct {
+		Servers serverWrapper `json:"servers"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	s.Servers = v.Servers.Servers
+
+	return nil
+}
+
+type TagsType []string
+
+func (t *TagsType) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Tags []string `json:"tag"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	(*t) = v.Tags
+
+	return nil
 }
 
 // Server represents a server
 type Server struct {
-	CoreNumber   int      `xml:"core_number"`
-	Hostname     string   `xml:"hostname"`
-	License      float64  `xml:"license"`
-	MemoryAmount int      `xml:"memory_amount"`
-	Plan         string   `xml:"plan"`
-	Progress     int      `xml:"progress"`
-	State        string   `xml:"state"`
-	Tags         []string `xml:"tags>tag"`
-	Title        string   `xml:"title"`
-	UUID         string   `xml:"uuid"`
-	Zone         string   `xml:"zone"`
+	CoreNumber   int      `xml:"core_number" json:"core_number,string"`
+	Hostname     string   `xml:"hostname" json:"hostname"`
+	License      float64  `xml:"license" json:"license"`
+	MemoryAmount int      `xml:"memory_amount" json:"memory_amount,string"`
+	Plan         string   `xml:"plan" json:"plan"`
+	Progress     int      `xml:"progress" json:"progress"`
+	State        string   `xml:"state" json:"state"`
+	Tags         TagsType `xml:"tags>tag" json:"tags"`
+	Title        string   `xml:"title" json:"title"`
+	UUID         string   `xml:"uuid" json:"uuid"`
+	Zone         string   `xml:"zone" json:"zone"`
 }
 
 // ServerDetails represents details about a server

--- a/upcloud/server.go
+++ b/upcloud/server.go
@@ -52,9 +52,9 @@ func (s *Servers) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type TagsType []string
+type TagSlice []string
 
-func (t *TagsType) UnmarshalJSON(b []byte) error {
+func (t *TagSlice) UnmarshalJSON(b []byte) error {
 	v := struct {
 		Tags []string `json:"tag"`
 	}{}
@@ -77,7 +77,7 @@ type Server struct {
 	Plan         string   `xml:"plan" json:"plan"`
 	Progress     int      `xml:"progress" json:"progress"`
 	State        string   `xml:"state" json:"state"`
-	Tags         TagsType `xml:"tags>tag" json:"tags"`
+	Tags         TagSlice `xml:"tags>tag" json:"tags"`
 	Title        string   `xml:"title" json:"title"`
 	UUID         string   `xml:"uuid" json:"uuid"`
 	Zone         string   `xml:"zone" json:"zone"`

--- a/upcloud/server_test.go
+++ b/upcloud/server_test.go
@@ -48,7 +48,7 @@ func TestUnmarshalServers(t *testing.T) {
                         "license": 0,
                         "memory_amount": "1024",
                         "plan": "1xCPU-1GB",
-                        "progress": 95,
+                        "progress": "95",
                         "state": "maintenance",
                         "tags": {
                             "tag": []

--- a/upcloud/server_test.go
+++ b/upcloud/server_test.go
@@ -1,6 +1,7 @@
 package upcloud
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"testing"
 
@@ -37,26 +38,32 @@ func TestUnmarshalServerConfiguratons(t *testing.T) {
 
 // TestUnmarshalServers tests that Servers and Server are unmarshaled correctly
 func TestUnmarshalServers(t *testing.T) {
-	originalXML := `<?xml version="1.0" encoding="utf-8"?>
-<servers>
-    <server>
-        <core_number>1</core_number>
-        <hostname>foo</hostname>
-        <license>0</license>
-        <memory_amount>1024</memory_amount>
-        <plan>1xCPU-1GB</plan>
-        <progress>95</progress>
-        <state>maintenance</state>
-        <tags>
-    </tags>
-        <title>foo.example.com</title>
-        <uuid>009114f1-cd89-4202-b057-5680eb6ba428</uuid>
-        <zone>uk-lon1</zone>
-    </server>
-</servers>`
+	originalJSON := `
+        {
+            "servers" : {
+                "server" : [
+                    {
+                        "core_number" : "1",
+                        "hostname": "foo",
+                        "license": 0,
+                        "memory_amount": "1024",
+                        "plan": "1xCPU-1GB",
+                        "progress": 95,
+                        "state": "maintenance",
+                        "tags": {
+                            "tag": []
+                        },
+                        "title": "foo.example.com",
+                        "uuid": "009114f1-cd89-4202-b057-5680eb6ba428",
+                        "zone": "uk-lon1"
+                    }
+                ]
+            }
+        }
+    `
 
 	servers := Servers{}
-	err := xml.Unmarshal([]byte(originalXML), &servers)
+	err := json.Unmarshal([]byte(originalJSON), &servers)
 	assert.Nil(t, err)
 	assert.Len(t, servers.Servers, 1)
 

--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -143,14 +143,17 @@ func (s *Service) GetServerDetails(r *request.GetServerDetailsRequest) (*upcloud
 // CreateServer creates a server and returns the server details for the newly created server
 func (s *Service) CreateServer(r *request.CreateServerRequest) (*upcloud.ServerDetails, error) {
 	serverDetails := upcloud.ServerDetails{}
-	requestBody, _ := xml.Marshal(r)
-	response, err := s.client.PerformPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
+	requestBody, _ := json.Marshal(r)
+	response, err := s.client.PerformJSONPostRequest(s.client.CreateRequestUrl(r.RequestURL()), requestBody)
 
 	if err != nil {
-		return nil, parseServiceError(err)
+		return nil, parseJSONServiceError(err)
 	}
 
-	xml.Unmarshal(response, &serverDetails)
+	err = json.Unmarshal(response, &serverDetails)
+	if err != nil {
+		return nil, err
+	}
 
 	return &serverDetails, nil
 }

--- a/upcloud/service/service.go
+++ b/upcloud/service/service.go
@@ -114,7 +114,7 @@ func (s *Service) GetServers() (*upcloud.Servers, error) {
 	response, err := s.basicJSONGetRequest("/server")
 
 	if err != nil {
-		return nil, parseServiceError(err)
+		return nil, parseJSONServiceError(err)
 	}
 
 	fmt.Println(string(response))
@@ -280,7 +280,7 @@ func (s *Service) DeleteServerAndStorages(r *request.DeleteServerAndStoragesRequ
 	err := s.client.PerformJSONDeleteRequest(s.client.CreateRequestUrl(r.RequestURL()))
 
 	if err != nil {
-		return parseServiceError(err)
+		return parseJSONServiceError(err)
 	}
 
 	return nil
@@ -738,6 +738,20 @@ func parseServiceError(err error) error {
 		serviceError := upcloud.Error{}
 		responseBody := clientError.ResponseBody
 		xml.Unmarshal(responseBody, &serviceError)
+
+		return &serviceError
+	}
+
+	return err
+}
+
+// Parses an error returned from the client into a service error object
+func parseJSONServiceError(err error) error {
+	// Parse service errors
+	if clientError, ok := err.(*client.Error); ok {
+		serviceError := upcloud.Error{}
+		responseBody := clientError.ResponseBody
+		json.Unmarshal(responseBody, &serviceError)
 
 		return &serviceError
 	}

--- a/upcloud/storage.go
+++ b/upcloud/storage.go
@@ -95,14 +95,14 @@ type ServerStorageDevice struct {
 
 // CreateServerStorageDevice represents a storage device for a CreateServerRequest
 type CreateServerStorageDevice struct {
-	XMLName xml.Name `xml:"storage_device"`
+	XMLName xml.Name `xml:"storage_device" json:"-"`
 
-	Action  string `xml:"action"`
-	Address string `xml:"address,omitempty"`
-	Storage string `xml:"storage"`
-	Title   string `xml:"title,omitempty"`
+	Action  string `xml:"action" json:"action"`
+	Address string `xml:"address,omitempty" json:"address,omitempty"`
+	Storage string `xml:"storage" json:"storage"`
+	Title   string `xml:"title,omitempty" json:"title,omitempty"`
 	// Storage size in gigabytes
-	Size int    `xml:"size"`
-	Tier string `xml:"tier,omitempty"`
-	Type string `xml:"type,omitempty"`
+	Size int    `xml:"size" json:"size"`
+	Tier string `xml:"tier,omitempty" json:"tier,omitempty"`
+	Type string `xml:"type,omitempty" json:"type,omitempty"`
 }


### PR DESCRIPTION
Changes:

* Switches `GetServers`, `CreateServer` and `DeleteServerAndStorages` to use JSON API as opposed to the XML API.
* Adds a simple example use of the API
* Adds an Error unmarshal test